### PR TITLE
refactor!: switch to function source

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -2,14 +2,13 @@ package iter
 
 // Chain returns a new iterator that first consumes the first iterator, then
 // the second.
-func (i *Iter[T]) Chain(o *Iter[T]) *Iter[T] {
-	tmp := Iter[T](func() (T, bool) {
-		next, ok := i.Next()
+func (i Iter[T]) Chain(o Iter[T]) Iter[T] {
+	return Iter[T](func() (T, bool) {
+		next, ok := i()
 		if ok {
 			return next, true
 		} else {
-			return o.Next()
+			return o()
 		}
 	})
-	return &tmp
 }

--- a/chain.go
+++ b/chain.go
@@ -1,24 +1,15 @@
 package iter
 
-type chainInner[T any] struct {
-	firstInner  *Iter[T]
-	secondInner *Iter[T]
-}
-
 // Chain returns a new iterator that first consumes the first iterator, then
 // the second.
 func (i *Iter[T]) Chain(o *Iter[T]) *Iter[T] {
-	return Wrap[T](&chainInner[T]{firstInner: i, secondInner: o})
-}
-
-func (i *chainInner[T]) HasNext() bool {
-	return i.firstInner.HasNext() || i.secondInner.HasNext()
-}
-
-func (i *chainInner[T]) Next() (T, error) {
-	if i.firstInner.HasNext() {
-		return i.firstInner.Next()
-	} else {
-		return i.secondInner.Next()
-	}
+	tmp := Iter[T](func() (T, bool) {
+		next, ok := i.Next()
+		if ok {
+			return next, true
+		} else {
+			return o.Next()
+		}
+	})
+	return &tmp
 }

--- a/chain_test.go
+++ b/chain_test.go
@@ -10,7 +10,7 @@ func TestChain(t *testing.T) {
 	iter := Elems([]int{1, 2}).Chain(Elems([]int{3, 4}))
 	actual := iter.Collect()
 	test.AssertDeepEq(actual, []int{1, 2, 3, 4}, t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 // operations should not take much longer than that of the range iterator

--- a/chan.go
+++ b/chan.go
@@ -5,12 +5,11 @@ package iter
 // from a channel, every time the next value is requested the program may end
 // up deadlocking if values have not been written: the same rules apply as
 // those for reading from a channel in the usual manner.
-func Receive[T any](ch *chan T) *Iter[T] {
-	tmp := Iter[T](func() (T, bool) {
+func Receive[T any](ch *chan T) Iter[T] {
+	return Iter[T](func() (T, bool) {
 		next, ok := <-*ch
 		return next, ok
 	})
-	return &tmp
 }
 
 // Send consumes the input iterator, sending all yielded values into the
@@ -18,9 +17,9 @@ func Receive[T any](ch *chan T) *Iter[T] {
 // improperly: if nobody is reading from the channel. Also note that this
 // method does not close the value after the values have been written, if you
 // want that to happen, you should do so yourself.
-func (i *Iter[T]) Send(ch *chan T) {
+func (i Iter[T]) Send(ch *chan T) {
 	for {
-		next, ok := i.Next()
+		next, ok := i()
 
 		if !ok {
 			return

--- a/chan_test.go
+++ b/chan_test.go
@@ -20,11 +20,11 @@ func TestReceive(t *testing.T) {
 
 	actualStart := iter.Take(2).Collect()
 
-	test.Assert(iter.HasNext(), t)
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 	test.AssertDeepEq(append(actualStart, iter.Collect()...), expected, t)
 
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 func BenchmarkReceive(b *testing.B) {

--- a/cycle.go
+++ b/cycle.go
@@ -4,8 +4,8 @@ package iter
 // then repeatedly returns the previous values. It also returns a boolean that
 // indicates whether the creation of this iterator was successful: it will fail
 // if the provided iterator is already empty.
-func (i *Iter[T]) Cycle() (*Iter[T], bool) {
-	next, ok := i.Next()
+func (i Iter[T]) Cycle() (Iter[T], bool) {
+	next, ok := i()
 	if !ok {
 		return nil, false
 	}
@@ -23,13 +23,13 @@ func (i *Iter[T]) Cycle() (*Iter[T], bool) {
 				return res, true
 			}
 
-			next, ok := i.Next()
+			next, ok := i()
 			if ok {
 				memory = append(memory, next)
 				return next, true
 			} else {
 				index = 0
-				return self.Next()
+				return self()
 			}
 		} else {
 			res := memory[index]
@@ -37,5 +37,5 @@ func (i *Iter[T]) Cycle() (*Iter[T], bool) {
 			return res, true
 		}
 	})
-	return &self, true
+	return self, true
 }

--- a/cycle_test.go
+++ b/cycle_test.go
@@ -7,39 +7,41 @@ import (
 )
 
 func TestCycle(t *testing.T) {
-	iter := Elems([]int{1, 2}).Cycle()
+	iter, ok := Elems([]int{1, 2}).Cycle()
 
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
+	test.Assert(ok, t)
 
 	test.AssertDeepEq(iter.Take(6).Collect(), []int{1, 2, 1, 2, 1, 2}, t)
 }
 
 func TestCyclePanic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("Cycle should've panicked")
-		}
-	}()
+	_, ok := Elems([]bool{}).Cycle()
 
-	Elems([]bool{}).Cycle()
+	test.Assert(!ok, t)
 }
 
 func BenchmarkCycle1(b *testing.B) {
-	Ints[int]().Take(1).Cycle().Take(b.N).Consume()
+	iter, _ := Ints[int]().Take(1).Cycle()
+	iter.Take(b.N).Consume()
 }
 
 func BenchmarkCycle100(b *testing.B) {
-	Ints[int]().Take(100).Cycle().Take(b.N).Consume()
+	iter, _ := Ints[int]().Take(100).Cycle()
+	iter.Take(b.N).Consume()
 }
 
 func BenchmarkCycleQuarter(b *testing.B) {
-	Ints[int]().Take(1 + (b.N / 4)).Cycle().Take(b.N).Consume()
+	iter, _ := Ints[int]().Take(1 + (b.N / 4)).Cycle()
+	iter.Take(b.N).Consume()
 }
 
 func BenchmarkCycleHalf(b *testing.B) {
-	Ints[int]().Take(1 + (b.N / 2)).Cycle().Take(b.N).Consume()
+	iter, _ := Ints[int]().Take(1 + (b.N / 2)).Cycle()
+	iter.Take(b.N).Consume()
 }
 
 func BenchmarkCycleFull(b *testing.B) {
-	Ints[int]().Take(1 + b.N).Cycle().Take(b.N).Consume()
+	iter, _ := Ints[int]().Take(1 + b.N).Cycle()
+	iter.Take(b.N).Consume()
 }

--- a/filter.go
+++ b/filter.go
@@ -1,50 +1,21 @@
 package iter
 
-type filterInner[T any] struct {
-	inner      *Iter[T]
-	filterFunc func(T) bool
-	cachedNext *T
-}
-
 // Filter returns a new iterator that only yields the values in the input
 // iterator that satisfy the provided function.
 func (i *Iter[T]) Filter(f func(T) bool) *Iter[T] {
-	return Wrap[T](&filterInner[T]{inner: i, filterFunc: f})
-}
+	tmp := Iter[T](func() (T, bool) {
+		for {
+			next, ok := i.Next()
 
-func (i *filterInner[T]) findNext() (T, error) {
-	for {
-		next, err := i.inner.Next()
+			if !ok {
+				var z T
+				return z, false
+			}
 
-		if err != nil {
-			break
+			if f(next) {
+				return next, true
+			}
 		}
-
-		if i.filterFunc(next) {
-			return next, nil
-		}
-	}
-
-	var z T
-	return z, IteratorExhaustedError
-}
-
-func (i *filterInner[T]) HasNext() bool {
-	if i.cachedNext != nil {
-		return true
-	}
-
-	next, err := i.findNext()
-	i.cachedNext = &next
-	return err == nil
-}
-
-func (i *filterInner[T]) Next() (T, error) {
-	if i.cachedNext != nil {
-		res := *i.cachedNext
-		i.cachedNext = nil
-		return res, nil
-	} else {
-		return i.findNext()
-	}
+	})
+	return &tmp
 }

--- a/filter.go
+++ b/filter.go
@@ -2,10 +2,10 @@ package iter
 
 // Filter returns a new iterator that only yields the values in the input
 // iterator that satisfy the provided function.
-func (i *Iter[T]) Filter(f func(T) bool) *Iter[T] {
-	tmp := Iter[T](func() (T, bool) {
+func (i Iter[T]) Filter(f func(T) bool) Iter[T] {
+	return Iter[T](func() (T, bool) {
 		for {
-			next, ok := i.Next()
+			next, ok := i()
 
 			if !ok {
 				var z T
@@ -17,5 +17,4 @@ func (i *Iter[T]) Filter(f func(T) bool) *Iter[T] {
 			}
 		}
 	})
-	return &tmp
 }

--- a/filter_map.go
+++ b/filter_map.go
@@ -2,16 +2,16 @@ package iter
 
 // FilterMapEndo returns a new iterator that yields the mapped values which are
 // produced without errors from the provided function.
-func (i *Iter[T]) FilterMapEndo(f func(T) (T, error)) *Iter[T] {
+func (i Iter[T]) FilterMapEndo(f func(T) (T, error)) Iter[T] {
 	return FilterMap(i, f)
 }
 
 // FilterMap returns a new iterator that yields the mapped values which are
 // produced without errors from the provided function.
-func FilterMap[T, U any](i *Iter[T], f func(T) (U, error)) *Iter[U] {
-	tmp := Iter[U](func() (U, bool) {
+func FilterMap[T, U any](i Iter[T], f func(T) (U, error)) Iter[U] {
+	return Iter[U](func() (U, bool) {
 		for {
-			next, ok := i.Next()
+			next, ok := i()
 
 			if !ok {
 				var z U
@@ -23,5 +23,4 @@ func FilterMap[T, U any](i *Iter[T], f func(T) (U, error)) *Iter[U] {
 			}
 		}
 	})
-	return &tmp
 }

--- a/filter_map.go
+++ b/filter_map.go
@@ -1,56 +1,27 @@
 package iter
 
-type filterMapInner[T, U any] struct {
-	inner         *Iter[T]
-	filterMapFunc func(T) (U, error)
-	cachedNext    *U
-}
-
 // FilterMapEndo returns a new iterator that yields the mapped values which are
 // produced without errors from the provided function.
 func (i *Iter[T]) FilterMapEndo(f func(T) (T, error)) *Iter[T] {
-	return Wrap[T](&filterMapInner[T, T]{inner: i, filterMapFunc: f})
+	return FilterMap(i, f)
 }
 
 // FilterMap returns a new iterator that yields the mapped values which are
 // produced without errors from the provided function.
 func FilterMap[T, U any](i *Iter[T], f func(T) (U, error)) *Iter[U] {
-	return Wrap[U](&filterMapInner[T, U]{inner: i, filterMapFunc: f})
-}
+	tmp := Iter[U](func() (U, bool) {
+		for {
+			next, ok := i.Next()
 
-func (i *filterMapInner[T, U]) findNext() (U, error) {
-	for {
-		next, err := i.inner.Next()
+			if !ok {
+				var z U
+				return z, false
+			}
 
-		if err != nil {
-			break
+			if mappedNext, err := f(next); err == nil {
+				return mappedNext, true
+			}
 		}
-
-		if mappedNext, err := i.filterMapFunc(next); err == nil {
-			return mappedNext, nil
-		}
-	}
-
-	var z U
-	return z, IteratorExhaustedError
-}
-
-func (i *filterMapInner[T, U]) HasNext() bool {
-	if i.cachedNext != nil {
-		return true
-	}
-
-	next, err := i.findNext()
-	i.cachedNext = &next
-	return err == nil
-}
-
-func (i *filterMapInner[T, U]) Next() (U, error) {
-	if i.cachedNext != nil {
-		res := *i.cachedNext
-		i.cachedNext = nil
-		return res, nil
-	} else {
-		return i.findNext()
-	}
+	})
+	return &tmp
 }

--- a/filter_map_test.go
+++ b/filter_map_test.go
@@ -31,10 +31,10 @@ func TestFilterMap(t *testing.T) {
 	actualFirst, _ := iter.Next()
 	expected := []int{1, 2}
 
-	test.Assert(iter.HasNext(), t)
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 	test.AssertDeepEq(append([]int{actualFirst}, iter.Collect()...), expected, t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 func BenchmarkFilterMapEndo(b *testing.B) {

--- a/filter_map_test.go
+++ b/filter_map_test.go
@@ -28,7 +28,7 @@ func TestFilterMap(t *testing.T) {
 		return strconv.Atoi(s)
 	})
 
-	actualFirst, _ := iter.Next()
+	actualFirst, _ := iter()
 	expected := []int{1, 2}
 
 	// test.Assert(iter.HasNext(), t)

--- a/filter_test.go
+++ b/filter_test.go
@@ -9,7 +9,7 @@ import (
 func TestFilter(t *testing.T) {
 	iter := Elems([]int{1, 2, 3, 4}).Filter(func(i int) bool { return i%2 == 0 })
 
-	actualFirst, _ := iter.Next()
+	actualFirst, _ := iter()
 	expected := []int{2, 4}
 
 	// test.Assert(iter.HasNext(), t)

--- a/filter_test.go
+++ b/filter_test.go
@@ -12,10 +12,10 @@ func TestFilter(t *testing.T) {
 	actualFirst, _ := iter.Next()
 	expected := []int{2, 4}
 
-	test.Assert(iter.HasNext(), t)
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 	test.AssertDeepEq(append([]int{actualFirst}, iter.Collect()...), expected, t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 func BenchmarkFilter(b *testing.B) {

--- a/flat_map.go
+++ b/flat_map.go
@@ -3,36 +3,35 @@ package iter
 // FlatMapEndo returns a new iterator that yields the values produced by
 // iterators returned by the provided function when it is applied to values
 // from the input iterator.
-func (i *Iter[T]) FlatMapEndo(f func(T) *Iter[T]) *Iter[T] {
+func (i Iter[T]) FlatMapEndo(f func(T) Iter[T]) Iter[T] {
 	return FlatMap(i, f)
 }
 
 // FlatMap returns a new iterator that yields the values produced by iterators
 // returned by the provided function when it is applied to values from the
 // input iterator.
-func FlatMap[T, U any](i *Iter[T], f func(T) *Iter[U]) *Iter[U] {
-	tmp := Iter[U](func() (U, bool) {
+func FlatMap[T, U any](i Iter[T], f func(T) Iter[U]) Iter[U] {
+	curr := Iter[U](func() (U, bool) {
 		var z U
 		return z, false
 	})
-	curr := &tmp
 
 	var self Iter[U]
 	self = Iter[U](func() (U, bool) {
-		next, ok := curr.Next()
+		next, ok := curr()
 
 		if ok {
 			return next, true
 		} else {
-			nextCurr, ok := i.Next()
+			nextCurr, ok := i()
 			if ok {
 				curr = f(nextCurr)
-				return self.Next()
+				return self()
 			} else {
 				var z U
 				return z, false
 			}
 		}
 	})
-	return &self
+	return self
 }

--- a/flat_map.go
+++ b/flat_map.go
@@ -1,72 +1,38 @@
 package iter
 
-type flatMapInner[T, U any] struct {
-	inner   *Iter[T]
-	mapFunc func(T) *Iter[U]
-	curr    *Iter[U]
-}
-
 // FlatMapEndo returns a new iterator that yields the values produced by
 // iterators returned by the provided function when it is applied to values
 // from the input iterator.
 func (i *Iter[T]) FlatMapEndo(f func(T) *Iter[T]) *Iter[T] {
-	return Wrap[T](&flatMapInner[T, T]{
-		inner:   i,
-		mapFunc: f,
-		curr:    Wrap[T](&emptyInner[T]{}),
-	})
+	return FlatMap(i, f)
 }
 
 // FlatMap returns a new iterator that yields the values produced by iterators
 // returned by the provided function when it is applied to values from the
 // input iterator.
 func FlatMap[T, U any](i *Iter[T], f func(T) *Iter[U]) *Iter[U] {
-	return Wrap[U](&flatMapInner[T, U]{
-		inner:   i,
-		mapFunc: f,
-		curr:    Wrap[U](&emptyInner[U]{}),
+	tmp := Iter[U](func() (U, bool) {
+		var z U
+		return z, false
 	})
-}
+	curr := &tmp
 
-func (i *flatMapInner[T, U]) findNext() (*Iter[U], error) {
-	next, err := i.inner.Next()
+	var self Iter[U]
+	self = Iter[U](func() (U, bool) {
+		next, ok := curr.Next()
 
-	if err == nil {
-		return i.mapFunc(next), nil
-	} else {
-		return &Iter[U]{}, err
-	}
-}
-
-func (i *flatMapInner[T, U]) HasNext() bool {
-	if i.curr.HasNext() {
-		return true
-	} else {
-		next, err := i.findNext()
-
-		if err != nil {
-			return false
+		if ok {
+			return next, true
+		} else {
+			nextCurr, ok := i.Next()
+			if ok {
+				curr = f(nextCurr)
+				return self.Next()
+			} else {
+				var z U
+				return z, false
+			}
 		}
-
-		i.curr = next
-		return i.HasNext()
-	}
-}
-
-func (i *flatMapInner[T, U]) Next() (U, error) {
-	next, err := i.curr.Next()
-
-	if err == nil {
-		return next, nil
-	} else {
-		next, err := i.findNext()
-
-		if err != nil {
-			var z U
-			return z, err
-		}
-
-		i.curr = next
-		return i.Next()
-	}
+	})
+	return &self
 }

--- a/flat_map_test.go
+++ b/flat_map_test.go
@@ -25,14 +25,14 @@ func TestFlatMap(t *testing.T) {
 		return Runes(s)
 	})
 
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 
 	actualStart := iter.Take(5).Collect()
 	expected := strings.Join(initial, "")
 
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 	test.AssertDeepEq(string(append(actualStart, iter.Collect()...)), expected, t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 //

--- a/flat_map_test.go
+++ b/flat_map_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFlatMapEndo(t *testing.T) {
 	initial := []int{1, 2, 3}
-	iter := Elems(initial).FlatMapEndo(func(i int) *Iter[int] {
+	iter := Elems(initial).FlatMapEndo(func(i int) Iter[int] {
 		return IntsFrom(i).Take(2)
 	})
 
@@ -21,7 +21,7 @@ func TestFlatMapEndo(t *testing.T) {
 
 func TestFlatMap(t *testing.T) {
 	initial := []string{"alpha", "beta", "gamma"}
-	iter := FlatMap(Elems(initial), func(s string) *Iter[rune] {
+	iter := FlatMap(Elems(initial), func(s string) Iter[rune] {
 		return Runes(s)
 	})
 
@@ -37,31 +37,31 @@ func TestFlatMap(t *testing.T) {
 
 //
 // func BenchmarkFlatMapEndo1(b *testing.B) {
-// 	InfRange(0, 1).FlatMapEndo(func(i int) *Iter[int] {
+// 	InfRange(0, 1).FlatMapEndo(func(i int) Iter[int] {
 // 		return Range(i, i+1, 1)
 // 	}).Take(b.N).Consume()
 // }
 //
 // func BenchmarkFlatMapEndo100(b *testing.B) {
-// 	InfRange(0, 1).FlatMapEndo(func(i int) *Iter[int] {
+// 	InfRange(0, 1).FlatMapEndo(func(i int) Iter[int] {
 // 		return Range(i, i+100, 1)
 // 	}).Take(b.N).Consume()
 // }
 //
 // func BenchmarkFlatMapEndoQuarter(b *testing.B) {
-// 	InfRange(0, 1).FlatMapEndo(func(i int) *Iter[int] {
+// 	InfRange(0, 1).FlatMapEndo(func(i int) Iter[int] {
 // 		return Range(i, b.N/4, 1)
 // 	}).Take(b.N).Consume()
 // }
 //
 // func BenchmarkFlatMapEndoHalf(b *testing.B) {
-// 	InfRange(0, 1).FlatMapEndo(func(i int) *Iter[int] {
+// 	InfRange(0, 1).FlatMapEndo(func(i int) Iter[int] {
 // 		return Range(i, b.N/2, 1)
 // 	}).Take(b.N).Consume()
 // }
 //
 // func BenchmarkFlatMapEndoFull(b *testing.B) {
-// 	InfRange(0, 1).FlatMapEndo(func(i int) *Iter[int] {
+// 	InfRange(0, 1).FlatMapEndo(func(i int) Iter[int] {
 // 		return Range(i, b.N, 1)
 // 	}).Take(b.N).Consume()
 // }

--- a/generator.go
+++ b/generator.go
@@ -1,86 +1,24 @@
 package iter
 
-type generatorInner[T any] struct {
-	generatorFunc func() T
-}
-
-// Gen returns an iterator that yields return values from the provided
-// function.
-func Gen[T any](f func() T) *Iter[T] {
-	return Wrap[T](&generatorInner[T]{generatorFunc: f})
-}
-
-func (i *generatorInner[T]) HasNext() bool {
-	return true
-}
-
-func (i *generatorInner[T]) Next() (T, error) {
-	return i.generatorFunc(), nil
-}
-
-type generatorWhileInner[T any] struct {
-	generatorFunc func() (T, error)
-	cachedNext    *T
-	failed        bool
-}
-
 // GenWhile returns an iterator that yields return values from the provided
 // function while it does not produce errors. After the first error, no more
 // values are yielded.
 func GenWhile[T any](f func() (T, error)) *Iter[T] {
-	return Wrap[T](&generatorWhileInner[T]{generatorFunc: f})
-}
-
-func (i *generatorWhileInner[T]) findNext() (T, error) {
-	next, err := i.generatorFunc()
-
-	if err == nil {
-		return next, nil
-	} else {
-		var z T
-		return z, err
-	}
-}
-
-func (i *generatorWhileInner[T]) HasNext() bool {
-	if i.failed {
-		return false
-	}
-
-	if i.cachedNext != nil {
-		return true
-	}
-
-	next, err := i.findNext()
-
-	if err == nil {
-		i.cachedNext = &next
-		return true
-	} else {
-		i.failed = true
-		return false
-	}
-}
-
-func (i *generatorWhileInner[T]) Next() (T, error) {
-	if i.failed {
-		var z T
-		return z, IteratorExhaustedError
-	}
-
-	if i.cachedNext != nil {
-		res := *i.cachedNext
-		i.cachedNext = nil
-		return res, nil
-	}
-
-	next, err := i.findNext()
-
-	if err != nil {
-		i.failed = true
-		var z T
-		return z, IteratorExhaustedError
-	}
-
-	return next, nil
+	failed := false
+	var self Iter[T]
+	self = Iter[T](func() (T, bool) {
+		if failed {
+			var z T
+			return z, false
+		} else {
+			next, err := f()
+			if err == nil {
+				return next, true
+			} else {
+				failed = true
+				return self.Next()
+			}
+		}
+	})
+	return &self
 }

--- a/generator.go
+++ b/generator.go
@@ -3,7 +3,7 @@ package iter
 // GenWhile returns an iterator that yields return values from the provided
 // function while it does not produce errors. After the first error, no more
 // values are yielded.
-func GenWhile[T any](f func() (T, error)) *Iter[T] {
+func GenWhile[T any](f func() (T, error)) Iter[T] {
 	failed := false
 	var self Iter[T]
 	self = Iter[T](func() (T, bool) {
@@ -16,9 +16,9 @@ func GenWhile[T any](f func() (T, error)) *Iter[T] {
 				return next, true
 			} else {
 				failed = true
-				return self.Next()
+				return self()
 			}
 		}
 	})
-	return &self
+	return self
 }

--- a/generator_test.go
+++ b/generator_test.go
@@ -27,7 +27,7 @@ func TestGenWhile(t *testing.T) {
 	// test.Assert(!iter.HasNext(), t)
 	// test.Assert(!iter.HasNext(), t)
 
-	_, err := iter.Next()
+	_, err := iter()
 
 	test.AssertNonNil(err, t)
 
@@ -39,7 +39,7 @@ func TestGenWhile(t *testing.T) {
 		}
 	})
 
-	_, err = iter.Next()
+	_, err = iter()
 
 	test.AssertNonNil(err, t)
 }

--- a/generator_test.go
+++ b/generator_test.go
@@ -7,21 +7,6 @@ import (
 	"mtoohey.com/iter/test"
 )
 
-func TestGen(t *testing.T) {
-	iter := Gen(func() int {
-		return 0
-	})
-
-	test.Assert(iter.HasNext(), t)
-	test.AssertDeepEq(iter.Take(5).Collect(), []int{0, 0, 0, 0, 0}, t)
-}
-
-func BenchmarkGen(b *testing.B) {
-	Gen(func() int {
-		return 0
-	}).Take(b.N).Consume()
-}
-
 func TestGenWhile(t *testing.T) {
 	b := false
 
@@ -33,14 +18,14 @@ func TestGenWhile(t *testing.T) {
 		}
 	})
 
-	test.Assert(iter.HasNext(), t)
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 	test.AssertDeepEq(iter.Take(5).Collect(), []int{0, 0, 0, 0, 0}, t)
 
 	b = true
 
-	test.Assert(!iter.HasNext(), t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 
 	_, err := iter.Next()
 

--- a/inspect.go
+++ b/inspect.go
@@ -4,9 +4,9 @@ package iter
 // but it applies the provided function to values of the iterator as they are
 // requested. This methodh differs from ForEach in that it is lazy, whereas
 // ForEach is not.
-func (i *Iter[T]) Inspect(f func(T)) *Iter[T] {
-	tmp := Iter[T](func() (T, bool) {
-		next, ok := i.Next()
+func (i Iter[T]) Inspect(f func(T)) Iter[T] {
+	return Iter[T](func() (T, bool) {
+		next, ok := i()
 		if ok {
 			f(next)
 			return next, true
@@ -15,5 +15,4 @@ func (i *Iter[T]) Inspect(f func(T)) *Iter[T] {
 			return z, false
 		}
 	})
-	return &tmp
 }

--- a/inspect.go
+++ b/inspect.go
@@ -1,30 +1,19 @@
 package iter
 
-type inspectInner[T any] struct {
-	inner       *Iter[T]
-	inspectFunc func(T)
-}
-
 // Inspect produces an iterator with identical values as the input iterator,
 // but it applies the provided function to values of the iterator as they are
 // requested. This methodh differs from ForEach in that it is lazy, whereas
 // ForEach is not.
 func (i *Iter[T]) Inspect(f func(T)) *Iter[T] {
-	return Wrap[T](&inspectInner[T]{inner: i, inspectFunc: f})
-}
-
-func (i *inspectInner[T]) HasNext() bool {
-	return i.inner.HasNext()
-}
-
-func (i *inspectInner[T]) Next() (T, error) {
-	next, err := i.inner.Next()
-
-	if err == nil {
-		i.inspectFunc(next)
-		return next, nil
-	} else {
-		var z T
-		return z, err
-	}
+	tmp := Iter[T](func() (T, bool) {
+		next, ok := i.Next()
+		if ok {
+			f(next)
+			return next, true
+		} else {
+			var z T
+			return z, false
+		}
+	})
+	return &tmp
 }

--- a/inspect_test.go
+++ b/inspect_test.go
@@ -18,14 +18,14 @@ func TestInspect(t *testing.T) {
 	})
 
 	test.AssertEq(actualNum, expectedNumBefore, t)
-	test.Assert(newIter.HasNext(), t)
+	// test.Assert(newIter.HasNext(), t)
 
 	actualSlice := newIter.Collect()
 	expectedSlice := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
 	test.AssertEq(actualNum, expectedNumAfter, t)
 	test.AssertDeepEq(actualSlice, expectedSlice, t)
-	test.Assert(!newIter.HasNext(), t)
+	// test.Assert(!newIter.HasNext(), t)
 }
 
 func BenchmarkInspect(b *testing.B) {

--- a/ints.go
+++ b/ints.go
@@ -2,48 +2,44 @@ package iter
 
 // Ints returns an iterator that produces integer values of the specified
 // generic type, starting from 0 and increasing by 1.
-func Ints[T integer]() *Iter[T] {
+func Ints[T integer]() Iter[T] {
 	var curr T
-	tmp := Iter[T](func() (T, bool) {
+	return Iter[T](func() (T, bool) {
 		res := curr
 		curr++
 		return res, true
 	})
-	return &tmp
 }
 
 // IntsFrom returns an iterator that produces integer values of the specified
 // generic type, starting from the provided value and increasing by 1.
-func IntsFrom[T integer](start T) *Iter[T] {
+func IntsFrom[T integer](start T) Iter[T] {
 	curr := start
-	tmp := Iter[T](func() (T, bool) {
+	return Iter[T](func() (T, bool) {
 		res := curr
 		curr++
 		return res, true
 	})
-	return &tmp
 }
 
 // IntsBy returns an iterator that produces integer values of the specified
 // generic type, starting from 0 and increasing by the provided value.
-func IntsBy[T integer](by T) *Iter[T] {
+func IntsBy[T integer](by T) Iter[T] {
 	var curr T
-	tmp := Iter[T](func() (T, bool) {
+	return Iter[T](func() (T, bool) {
 		res := curr
 		curr += by
 		return res, true
 	})
-	return &tmp
 }
 
 // IntsFromBy returns an iterator that produces integer values of the specified
 // generic type, starting from, and increasing by the provided values.
-func IntsFromBy[T integer](start T, by T) *Iter[T] {
+func IntsFromBy[T integer](start T, by T) Iter[T] {
 	curr := start
-	tmp := Iter[T](func() (T, bool) {
+	return Iter[T](func() (T, bool) {
 		res := curr
 		curr += by
 		return res, true
 	})
-	return &tmp
 }

--- a/ints.go
+++ b/ints.go
@@ -1,38 +1,49 @@
 package iter
 
-type intsInner[T integer] struct {
-	curr T
-	by   T
-}
-
 // Ints returns an iterator that produces integer values of the specified
 // generic type, starting from 0 and increasing by 1.
 func Ints[T integer]() *Iter[T] {
-	return Wrap[T](&intsInner[T]{curr: 0, by: 1})
+	var curr T
+	tmp := Iter[T](func() (T, bool) {
+		res := curr
+		curr++
+		return res, true
+	})
+	return &tmp
 }
 
 // IntsFrom returns an iterator that produces integer values of the specified
 // generic type, starting from the provided value and increasing by 1.
 func IntsFrom[T integer](start T) *Iter[T] {
-	return Wrap[T](&intsInner[T]{curr: start, by: 1})
+	curr := start
+	tmp := Iter[T](func() (T, bool) {
+		res := curr
+		curr++
+		return res, true
+	})
+	return &tmp
 }
 
 // IntsBy returns an iterator that produces integer values of the specified
 // generic type, starting from 0 and increasing by the provided value.
 func IntsBy[T integer](by T) *Iter[T] {
-	return Wrap[T](&intsInner[T]{by: by})
+	var curr T
+	tmp := Iter[T](func() (T, bool) {
+		res := curr
+		curr += by
+		return res, true
+	})
+	return &tmp
 }
 
 // IntsFromBy returns an iterator that produces integer values of the specified
 // generic type, starting from, and increasing by the provided values.
 func IntsFromBy[T integer](start T, by T) *Iter[T] {
-	return Wrap[T](&intsInner[T]{curr: start, by: by})
-}
-
-func (i *intsInner[T]) HasNext() bool { return true }
-
-func (i *intsInner[T]) Next() (T, error) {
-	res := i.curr
-	i.curr = i.curr + i.by
-	return res, nil
+	curr := start
+	tmp := Iter[T](func() (T, bool) {
+		res := curr
+		curr += by
+		return res, true
+	})
+	return &tmp
 }

--- a/iter_test.go
+++ b/iter_test.go
@@ -69,11 +69,11 @@ func TestFind(t *testing.T) {
 
 	test.AssertEq(actual, 7, t)
 
-	_, err := Elems([]bool{}).Find(func(b bool) bool {
+	_, ok := Elems([]bool{}).Find(func(b bool) bool {
 		return true
 	})
 
-	test.AssertNonNil(err, t)
+	test.AssertNonNil(ok, t)
 }
 
 func TestFindMapEndo(t *testing.T) {
@@ -87,11 +87,11 @@ func TestFindMapEndo(t *testing.T) {
 
 	test.AssertEq(actual, 7, t)
 
-	_, err := Elems([]bool{}).FindMapEndo(func(b bool) (bool, error) {
+	_, ok := Elems([]bool{}).FindMapEndo(func(b bool) (bool, error) {
 		return true, nil
 	})
 
-	test.AssertNonNil(err, t)
+	test.AssertNonNil(ok, t)
 }
 
 func TestFindMap(t *testing.T) {
@@ -105,11 +105,11 @@ func TestFindMap(t *testing.T) {
 
 	test.AssertEq(actual, 7, t)
 
-	_, err := FindMap(Elems([]bool{}), func(b bool) (bool, error) {
+	_, ok := FindMap(Elems([]bool{}), func(b bool) (bool, error) {
 		return true, nil
 	})
 
-	test.AssertNonNil(err, t)
+	test.AssertNonNil(ok, t)
 }
 
 func TestFoldEndo(t *testing.T) {
@@ -159,9 +159,9 @@ func TestLast(t *testing.T) {
 
 	test.AssertEq(actual, 10, t)
 
-	_, err := Elems([]bool{}).Last()
+	_, ok := Elems([]bool{}).Last()
 
-	test.AssertNonNil(err, t)
+	test.AssertNonNil(ok, t)
 }
 
 func BenchmarkLast(b *testing.B) {
@@ -173,13 +173,13 @@ func TestNth(t *testing.T) {
 
 	test.AssertEq(actual, 7, t)
 
-	_, err := IntsFrom(1).Take(10).Nth(17)
+	_, ok := IntsFrom(1).Take(10).Nth(17)
 
-	test.AssertNonNil(err, t)
+	test.AssertNonNil(ok, t)
 
-	_, err = IntsFrom(1).Take(10).Nth(11)
+	_, ok = IntsFrom(1).Take(10).Nth(11)
 
-	test.AssertNonNil(err, t)
+	test.AssertNonNil(ok, t)
 }
 
 func BenchmarkNth(b *testing.B) {
@@ -200,7 +200,7 @@ func BenchmarkPartition(b *testing.B) {
 }
 
 func TestTryFoldEndo(t *testing.T) {
-	actual, err := IntsBy(2).Take(3).TryFoldEndo(0, func(curr int, next int) (int, error) {
+	actual, ok := IntsBy(2).Take(3).TryFoldEndo(0, func(curr int, next int) (int, error) {
 		if next%2 == 0 {
 			return curr + next, nil
 		} else {
@@ -208,10 +208,10 @@ func TestTryFoldEndo(t *testing.T) {
 		}
 	})
 
-	test.AssertNil(err, t)
+	test.AssertNil(ok, t)
 	test.AssertEq(actual, 6, t)
 
-	_, err = Ints[int]().Take(5).TryFoldEndo(0, func(curr int, next int) (int, error) {
+	_, ok = Ints[int]().Take(5).TryFoldEndo(0, func(curr int, next int) (int, error) {
 		if next%2 == 0 {
 			return curr + next, nil
 		} else {
@@ -219,7 +219,7 @@ func TestTryFoldEndo(t *testing.T) {
 		}
 	})
 
-	test.AssertNonNil(err, t)
+	test.AssertNonNil(ok, t)
 }
 
 func BenchmarkTryFoldEndo(b *testing.B) {
@@ -294,7 +294,7 @@ func BenchmarkTryForEach(b *testing.B) {
 }
 
 func TestReduce(t *testing.T) {
-	actual, err := Ints[int]().Take(5).Reduce(func(curr int, next int) int {
+	actual, ok := Ints[int]().Take(5).Reduce(func(curr int, next int) int {
 		if next > curr {
 			return next
 		} else {
@@ -302,7 +302,7 @@ func TestReduce(t *testing.T) {
 		}
 	})
 
-	test.AssertNil(err, t)
+	test.Assert(ok, t)
 	test.AssertEq(actual, 4, t)
 }
 

--- a/map.go
+++ b/map.go
@@ -2,11 +2,6 @@ package iter
 
 import "github.com/barweiss/go-tuple"
 
-type mapDataInner[T comparable, U any] struct {
-	innerKeys *Iter[T]
-	mapping   map[T]U
-}
-
 // KVZip returns an iterator that yields tuples of the input map's keys and
 // values. While the value lookup occurs lazily, the keys must be accumulated
 // immediately when the iterator is created, so this operation can be expensive
@@ -15,54 +10,42 @@ func KVZip[T comparable, U any](m map[T]U) *Iter[tuple.T2[T, U]] {
 	var keys []T
 
 	for key := range m {
+		// TODO: try refactoring to use a goroutine and channel here so we
+		// don't have to take up so much memory
 		keys = append(keys, key)
 	}
 
-	return Wrap[tuple.T2[T, U]](&mapDataInner[T, U]{innerKeys: Elems(keys), mapping: m})
-}
-
-func (i *mapDataInner[T, U]) HasNext() bool {
-	return i.innerKeys.HasNext()
-}
-
-func (i *mapDataInner[T, U]) Next() (tuple.T2[T, U], error) {
-	key, err := i.innerKeys.Next()
-
-	if err == nil {
-		return tuple.New2(key, i.mapping[key]), nil
-	} else {
-		return tuple.T2[T, U]{}, IteratorExhaustedError
-	}
-}
-
-type mapFuncInner[T, U any] struct {
-	inner   *Iter[T]
-	mapFunc func(T) U
+	tmp := Iter[tuple.T2[T, U]](func() (tuple.T2[T, U], bool) {
+		if len(keys) > 0 {
+			// PERF: is going from back to front here faster?
+			next := keys[0]
+			keys = keys[1:]
+			return tuple.New2(next, m[next]), true
+		} else {
+			var z tuple.T2[T, U]
+			return z, false
+		}
+	})
+	return &tmp
 }
 
 // MapEndo returns a new iterator that yields the results of applying the
 // provided function to the input iterator.
 func (i *Iter[T]) MapEndo(f func(T) T) *Iter[T] {
-	return Wrap[T](&mapFuncInner[T, T]{inner: i, mapFunc: f})
+	return Map(i, f)
 }
 
 // Map returns a new iterator that yields the results of applying the provided
 // function to the input iterator.
 func Map[T, U any](i *Iter[T], f func(T) U) *Iter[U] {
-	return Wrap[U](&mapFuncInner[T, U]{inner: i, mapFunc: f})
-}
-
-func (i *mapFuncInner[T, U]) HasNext() bool {
-	return i.inner.HasNext()
-}
-
-func (i *mapFuncInner[T, U]) Next() (U, error) {
-	next, err := i.inner.Next()
-
-	if err == nil {
-		return i.mapFunc(next), nil
-	} else {
-		var z U
-		return z, err
-	}
+	tmp := Iter[U](func() (U, bool) {
+		next, ok := i.Next()
+		if ok {
+			return f(next), true
+		} else {
+			var z U
+			return z, false
+		}
+	})
+	return &tmp
 }

--- a/map.go
+++ b/map.go
@@ -6,7 +6,7 @@ import "github.com/barweiss/go-tuple"
 // values. While the value lookup occurs lazily, the keys must be accumulated
 // immediately when the iterator is created, so this operation can be expensive
 // if performance is important.
-func KVZip[T comparable, U any](m map[T]U) *Iter[tuple.T2[T, U]] {
+func KVZip[T comparable, U any](m map[T]U) Iter[tuple.T2[T, U]] {
 	var keys []T
 
 	for key := range m {
@@ -15,7 +15,7 @@ func KVZip[T comparable, U any](m map[T]U) *Iter[tuple.T2[T, U]] {
 		keys = append(keys, key)
 	}
 
-	tmp := Iter[tuple.T2[T, U]](func() (tuple.T2[T, U], bool) {
+	return Iter[tuple.T2[T, U]](func() (tuple.T2[T, U], bool) {
 		if len(keys) > 0 {
 			// PERF: is going from back to front here faster?
 			next := keys[0]
@@ -26,20 +26,19 @@ func KVZip[T comparable, U any](m map[T]U) *Iter[tuple.T2[T, U]] {
 			return z, false
 		}
 	})
-	return &tmp
 }
 
 // MapEndo returns a new iterator that yields the results of applying the
 // provided function to the input iterator.
-func (i *Iter[T]) MapEndo(f func(T) T) *Iter[T] {
+func (i Iter[T]) MapEndo(f func(T) T) Iter[T] {
 	return Map(i, f)
 }
 
 // Map returns a new iterator that yields the results of applying the provided
 // function to the input iterator.
-func Map[T, U any](i *Iter[T], f func(T) U) *Iter[U] {
-	tmp := Iter[U](func() (U, bool) {
-		next, ok := i.Next()
+func Map[T, U any](i Iter[T], f func(T) U) Iter[U] {
+	return Iter[U](func() (U, bool) {
+		next, ok := i()
 		if ok {
 			return f(next), true
 		} else {
@@ -47,5 +46,4 @@ func Map[T, U any](i *Iter[T], f func(T) U) *Iter[U] {
 			return z, false
 		}
 	})
-	return &tmp
 }

--- a/map_test.go
+++ b/map_test.go
@@ -23,9 +23,9 @@ func TestMapData(t *testing.T) {
 
 	iter := KVZip(m)
 
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 	test.AssertElemsDeepEq(iter.Collect(), expected, t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 func BenchmarkMapData(b *testing.B) {
@@ -40,7 +40,7 @@ func TestMapEndoFunc(t *testing.T) {
 	iter := Elems([]string{"item1", "item2"}).MapEndo(func(s string) string { return strings.ToUpper(s) })
 
 	test.AssertDeepEq(iter.Collect(), []string{"ITEM1", "ITEM2"}, t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 func BenchmarkMapEndoFunc(b *testing.B) {
@@ -53,7 +53,7 @@ func TestMapFunc(t *testing.T) {
 	iter := Map(Elems([]string{"item1", "item2"}), func(s string) int { return len(s) })
 
 	test.AssertDeepEq(iter.Collect(), []int{5, 5}, t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 func BenchmarkMapFunc(b *testing.B) {

--- a/map_while.go
+++ b/map_while.go
@@ -1,83 +1,36 @@
 package iter
 
-type mapWhileInner[T, U any] struct {
-	inner        *Iter[T]
-	mapWhileFunc func(T) (U, error)
-	cachedNext   *U
-	failed       bool
-}
-
 // MapWhileEndo returns a new iterator that yields the values produced by
 // applying the provided function to the values of the input iterator, until
 // the first error occurs. At that point, no further values are returned.
 func (i *Iter[T]) MapWhileEndo(f func(T) (T, error)) *Iter[T] {
-	return Wrap[T](&mapWhileInner[T, T]{inner: i, mapWhileFunc: f})
+	return MapWhile(i, f)
 }
 
 // MapWhile returns a new iterator that yields the values produced by applying
 // the provided function to the values of the input iterator, until the first
 // error occurs. At that point, no further values are returned.
 func MapWhile[T, U any](i *Iter[T], f func(T) (U, error)) *Iter[U] {
-	return Wrap[U](&mapWhileInner[T, U]{inner: i, mapWhileFunc: f})
-}
-
-func (i *mapWhileInner[T, U]) findNext() (U, error) {
-	for {
-		next, err := i.inner.Next()
-
-		if err != nil {
-			break
-		}
-
-		if mappedNext, err := i.mapWhileFunc(next); err == nil {
-			return mappedNext, nil
+	failed := false
+	tmp := Iter[U](func() (U, bool) {
+		if failed {
+			var z U
+			return z, false
 		} else {
-			break
+			next, ok := i.Next()
+			if ok {
+				if mappedNext, err := f(next); err == nil {
+					return mappedNext, true
+				} else {
+					failed = true
+					var z U
+					return z, false
+				}
+			} else {
+				var z U
+				return z, false
+			}
 		}
-	}
-	var z U
-	return z, IteratorExhaustedError
-}
-
-func (i *mapWhileInner[T, U]) HasNext() bool {
-	if i.failed {
-		return false
-	}
-
-	if i.cachedNext != nil {
-		return true
-	}
-
-	next, err := i.findNext()
-
-	if err == nil {
-		i.cachedNext = &next
-		return true
-	} else {
-		i.failed = true
-		return false
-	}
-}
-
-func (i *mapWhileInner[T, U]) Next() (U, error) {
-	if i.failed {
-		var z U
-		return z, IteratorExhaustedError
-	}
-
-	if i.cachedNext != nil {
-		res := *i.cachedNext
-		i.cachedNext = nil
-		return res, nil
-	}
-
-	next, err := i.findNext()
-
-	if err != nil {
-		i.failed = true
-		var z U
-		return z, IteratorExhaustedError
-	}
-
-	return next, err
+	})
+	return &tmp
 }

--- a/map_while.go
+++ b/map_while.go
@@ -3,21 +3,21 @@ package iter
 // MapWhileEndo returns a new iterator that yields the values produced by
 // applying the provided function to the values of the input iterator, until
 // the first error occurs. At that point, no further values are returned.
-func (i *Iter[T]) MapWhileEndo(f func(T) (T, error)) *Iter[T] {
+func (i Iter[T]) MapWhileEndo(f func(T) (T, error)) Iter[T] {
 	return MapWhile(i, f)
 }
 
 // MapWhile returns a new iterator that yields the values produced by applying
 // the provided function to the values of the input iterator, until the first
 // error occurs. At that point, no further values are returned.
-func MapWhile[T, U any](i *Iter[T], f func(T) (U, error)) *Iter[U] {
+func MapWhile[T, U any](i Iter[T], f func(T) (U, error)) Iter[U] {
 	failed := false
-	tmp := Iter[U](func() (U, bool) {
+	return Iter[U](func() (U, bool) {
 		if failed {
 			var z U
 			return z, false
 		} else {
-			next, ok := i.Next()
+			next, ok := i()
 			if ok {
 				if mappedNext, err := f(next); err == nil {
 					return mappedNext, true
@@ -32,5 +32,4 @@ func MapWhile[T, U any](i *Iter[T], f func(T) (U, error)) *Iter[U] {
 			}
 		}
 	})
-	return &tmp
 }

--- a/map_while_test.go
+++ b/map_while_test.go
@@ -52,7 +52,7 @@ func TestMapWhile(t *testing.T) {
 	test.AssertDeepEq(mappedWhileIter.Collect(), []int{11, 13}, t)
 	// test.Assert(!mappedWhileIter.HasNext(), t)
 
-	_, err := mappedWhileIter.Next()
+	_, err := mappedWhileIter()
 
 	test.AssertNonNil(err, t)
 	test.AssertDeepEq(initialIter.Collect(), []string{"long string again"}, t)

--- a/map_while_test.go
+++ b/map_while_test.go
@@ -25,9 +25,9 @@ func TestMapWhileEndo(t *testing.T) {
 		return i, nil
 	}).Consume()
 
-	Ints[int]().Take(0).MapWhileEndo(func(i int) (int, error) {
-		return i, nil
-	}).HasNext()
+	// Ints[int]().Take(0).MapWhileEndo(func(i int) (int, error) {
+	// 	return i, nil
+	// }).HasNext()
 }
 
 func BenchmarkMapWhileEndo(b *testing.B) {
@@ -47,10 +47,10 @@ func TestMapWhile(t *testing.T) {
 		}
 	})
 
-	test.Assert(mappedWhileIter.HasNext(), t)
-	test.Assert(mappedWhileIter.HasNext(), t)
+	// test.Assert(mappedWhileIter.HasNext(), t)
+	// test.Assert(mappedWhileIter.HasNext(), t)
 	test.AssertDeepEq(mappedWhileIter.Collect(), []int{11, 13}, t)
-	test.Assert(!mappedWhileIter.HasNext(), t)
+	// test.Assert(!mappedWhileIter.HasNext(), t)
 
 	_, err := mappedWhileIter.Next()
 

--- a/ordered_iter.go
+++ b/ordered_iter.go
@@ -3,7 +3,7 @@ package iter
 import "github.com/barweiss/go-tuple"
 
 // Min returns the minimum value in the provided iterator.
-func Min[T ordered](oi *Iter[T]) (T, bool) {
+func Min[T ordered](oi Iter[T]) (T, bool) {
 	return oi.Reduce(func(curr T, next T) T {
 		if curr < next {
 			return curr
@@ -15,8 +15,8 @@ func Min[T ordered](oi *Iter[T]) (T, bool) {
 
 // MinByKey returns the value with the minimum result after the application of
 // the provided function.
-func MinByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, bool) {
-	init, ok := oi.Next()
+func MinByKey[T any, U ordered](oi Iter[T], key func(T) U) (T, bool) {
+	init, ok := oi()
 
 	if !ok {
 		var z T
@@ -34,7 +34,7 @@ func MinByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, bool) {
 }
 
 // Max returns the maximum value in the provided iterator.
-func Max[T ordered](oi *Iter[T]) (T, bool) {
+func Max[T ordered](oi Iter[T]) (T, bool) {
 	return oi.Reduce(func(curr T, next T) T {
 		if curr > next {
 			return curr
@@ -46,8 +46,8 @@ func Max[T ordered](oi *Iter[T]) (T, bool) {
 
 // MaxByKey returns the value with the maximum result after the application of
 // the provided function.
-func MaxByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, bool) {
-	init, ok := oi.Next()
+func MaxByKey[T any, U ordered](oi Iter[T], key func(T) U) (T, bool) {
+	init, ok := oi()
 
 	if !ok {
 		var z T
@@ -65,7 +65,7 @@ func MaxByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, bool) {
 }
 
 // Sum returns the sum of all the values in the provided iterator.
-func Sum[T ordered](oi *Iter[T]) T {
+func Sum[T ordered](oi Iter[T]) T {
 	var z T
 	return oi.FoldEndo(z, func(curr, next T) T { return curr + next })
 }

--- a/ordered_iter.go
+++ b/ordered_iter.go
@@ -3,7 +3,7 @@ package iter
 import "github.com/barweiss/go-tuple"
 
 // Min returns the minimum value in the provided iterator.
-func Min[T ordered](oi *Iter[T]) (T, error) {
+func Min[T ordered](oi *Iter[T]) (T, bool) {
 	return oi.Reduce(func(curr T, next T) T {
 		if curr < next {
 			return curr
@@ -15,12 +15,12 @@ func Min[T ordered](oi *Iter[T]) (T, error) {
 
 // MinByKey returns the value with the minimum result after the application of
 // the provided function.
-func MinByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, error) {
-	init, err := oi.Next()
+func MinByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, bool) {
+	init, ok := oi.Next()
 
-	if err != nil {
+	if !ok {
 		var z T
-		return z, IteratorExhaustedError
+		return z, false
 	}
 
 	return Fold(oi, tuple.New2(init, key(init)), func(curr tuple.T2[T, U], next T) tuple.T2[T, U] {
@@ -30,11 +30,11 @@ func MinByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, error) {
 		} else {
 			return tuple.New2(next, keyNext)
 		}
-	}).V1, nil
+	}).V1, true
 }
 
 // Max returns the maximum value in the provided iterator.
-func Max[T ordered](oi *Iter[T]) (T, error) {
+func Max[T ordered](oi *Iter[T]) (T, bool) {
 	return oi.Reduce(func(curr T, next T) T {
 		if curr > next {
 			return curr
@@ -46,12 +46,12 @@ func Max[T ordered](oi *Iter[T]) (T, error) {
 
 // MaxByKey returns the value with the maximum result after the application of
 // the provided function.
-func MaxByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, error) {
-	init, err := oi.Next()
+func MaxByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, bool) {
+	init, ok := oi.Next()
 
-	if err != nil {
+	if !ok {
 		var z T
-		return z, IteratorExhaustedError
+		return z, false
 	}
 
 	return Fold(oi, tuple.New2(init, key(init)), func(curr tuple.T2[T, U], next T) tuple.T2[T, U] {
@@ -61,7 +61,7 @@ func MaxByKey[T any, U ordered](oi *Iter[T], key func(T) U) (T, error) {
 		} else {
 			return tuple.New2(next, keyNext)
 		}
-	}).V1, nil
+	}).V1, true
 }
 
 // Sum returns the sum of all the values in the provided iterator.

--- a/ordered_iter_test.go
+++ b/ordered_iter_test.go
@@ -9,14 +9,14 @@ import (
 func TestMin(t *testing.T) {
 	ordered := Ints[int]().Take(10)
 
-	actual, err := Min(ordered)
+	actual, ok := Min(ordered)
 
-	test.AssertNil(err, t)
+	test.Assert(ok, t)
 	test.AssertEq(actual, 0, t)
 
-	_, err = Min(ordered)
+	_, ok = Min(ordered)
 
-	test.AssertNonNil(err, t)
+	test.Assert(!ok, t)
 
 	Min(IntsBy(-1).Take(2))
 }
@@ -28,26 +28,26 @@ func BenchmarkMin(b *testing.B) {
 func TestMinByKey(t *testing.T) {
 	ordered := Ints[int]().Take(10)
 
-	actual, err := MinByKey(ordered, func(n int) int {
+	actual, ok := MinByKey(ordered, func(n int) int {
 		return n * -1
 	})
 
-	test.AssertNil(err, t)
+	test.Assert(ok, t)
 	test.AssertEq(actual, 9, t)
 
-	_, err = MinByKey(ordered, func(n int) int {
+	_, ok = MinByKey(ordered, func(n int) int {
 		return n * -1
 	})
 
-	test.AssertNonNil(err, t)
+	test.Assert(!ok, t)
 
 	ordered = IntsBy(-1).Take(10)
 
-	actual, err = MinByKey(ordered, func(n int) int {
+	actual, ok = MinByKey(ordered, func(n int) int {
 		return n * -1
 	})
 
-	test.AssertNil(err, t)
+	test.Assert(ok, t)
 	test.AssertEq(actual, 0, t)
 }
 
@@ -60,14 +60,14 @@ func BenchmarkMinByKey(b *testing.B) {
 func TestMax(t *testing.T) {
 	ordered := Ints[int]().Take(10)
 
-	actual, err := Max(ordered)
+	actual, ok := Max(ordered)
 
-	test.AssertNil(err, t)
+	test.Assert(ok, t)
 	test.AssertEq(actual, 9, t)
 
-	_, err = Max(ordered)
+	_, ok = Max(ordered)
 
-	test.AssertNonNil(err, t)
+	test.Assert(!ok, t)
 
 	Max(IntsBy(-1).Take(2))
 }
@@ -79,26 +79,26 @@ func BenchmarkMax(b *testing.B) {
 func TestMaxByKey(t *testing.T) {
 	ordered := Ints[int]().Take(10)
 
-	actual, err := MaxByKey(ordered, func(n int) int {
+	actual, ok := MaxByKey(ordered, func(n int) int {
 		return n * -1
 	})
 
-	test.AssertNil(err, t)
+	test.Assert(ok, t)
 	test.AssertEq(actual, 0, t)
 
-	_, err = MaxByKey(ordered, func(n int) int {
+	_, ok = MaxByKey(ordered, func(n int) int {
 		return n * -1
 	})
 
-	test.AssertNonNil(err, t)
+	test.Assert(!ok, t)
 
 	ordered = IntsBy(-1).Take(10)
 
-	actual, err = MaxByKey(ordered, func(n int) int {
+	actual, ok = MaxByKey(ordered, func(n int) int {
 		return n * -1
 	})
 
-	test.AssertNil(err, t)
+	test.Assert(ok, t)
 	test.AssertEq(actual, -9, t)
 }
 

--- a/slice.go
+++ b/slice.go
@@ -1,26 +1,16 @@
 package iter
 
-type sliceInner[T any] struct {
-	index int
-	slice []T
-}
-
 // Elems returns an iterator over the values of the provided slice.
 func Elems[T any](s []T) *Iter[T] {
-	return Wrap[T](&sliceInner[T]{index: 0, slice: s})
-}
-
-func (i *sliceInner[T]) HasNext() bool {
-	return i.index < len(i.slice)
-}
-
-func (i *sliceInner[T]) Next() (T, error) {
-	if i.index >= len(i.slice) {
-		var z T
-		return z, IteratorExhaustedError
-	}
-
-	res := i.slice[i.index]
-	i.index = i.index + 1
-	return res, nil
+	index := -1
+	tmp := Iter[T](func() (T, bool) {
+		index++
+		if len(s) > index {
+			return s[index], true
+		} else {
+			var z T
+			return z, false
+		}
+	})
+	return &tmp
 }

--- a/slice.go
+++ b/slice.go
@@ -1,9 +1,9 @@
 package iter
 
 // Elems returns an iterator over the values of the provided slice.
-func Elems[T any](s []T) *Iter[T] {
+func Elems[T any](s []T) Iter[T] {
 	index := -1
-	tmp := Iter[T](func() (T, bool) {
+	return Iter[T](func() (T, bool) {
 		index++
 		if len(s) > index {
 			return s[index], true
@@ -12,5 +12,4 @@ func Elems[T any](s []T) *Iter[T] {
 			return z, false
 		}
 	})
-	return &tmp
 }

--- a/step_by.go
+++ b/step_by.go
@@ -2,11 +2,6 @@ package iter
 
 import "fmt"
 
-type stepByInner[T any] struct {
-	inner *Iter[T]
-	step  int
-}
-
 // StepBy returns a new iterator that returns every nth value of the input
 // iterator. The provided step value must be positive, otherwise the method
 // will panic.
@@ -15,15 +10,10 @@ func (i *Iter[T]) StepBy(step int) *Iter[T] {
 		panic(fmt.Sprintf("invalid StepBy step: %d", step))
 	}
 
-	return Wrap[T](&stepByInner[T]{inner: i, step: step})
-}
-
-func (i *stepByInner[T]) HasNext() bool {
-	return i.inner.HasNext()
-}
-
-func (i *stepByInner[T]) Next() (T, error) {
-	res, err := i.inner.Next()
-	i.inner.Take(i.step - 1).Consume()
-	return res, err
+	tmp := Iter[T](func() (T, bool) {
+		res, err := i.Next()
+		i.Take(step - 1).Consume()
+		return res, err
+	})
+	return &tmp
 }

--- a/step_by.go
+++ b/step_by.go
@@ -5,15 +5,14 @@ import "fmt"
 // StepBy returns a new iterator that returns every nth value of the input
 // iterator. The provided step value must be positive, otherwise the method
 // will panic.
-func (i *Iter[T]) StepBy(step int) *Iter[T] {
+func (i Iter[T]) StepBy(step int) Iter[T] {
 	if step < 1 {
 		panic(fmt.Sprintf("invalid StepBy step: %d", step))
 	}
 
-	tmp := Iter[T](func() (T, bool) {
-		res, err := i.Next()
+	return Iter[T](func() (T, bool) {
+		res, err := i()
 		i.Take(step - 1).Consume()
 		return res, err
 	})
-	return &tmp
 }

--- a/step_by_test.go
+++ b/step_by_test.go
@@ -9,9 +9,9 @@ import (
 func TestStepBy(t *testing.T) {
 	iter := Ints[int]().Take(10).StepBy(3)
 
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 	test.AssertDeepEq(iter.Collect(), []int{0, 3, 6, 9}, t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 func TestStepByPanic(t *testing.T) {

--- a/string.go
+++ b/string.go
@@ -11,38 +11,30 @@ func Runes(s string) *Iter[rune] {
 	return Elems(runes)
 }
 
-type splitByRuneInner struct {
-	string string
-	rune   rune
-	index  int
-}
-
 // SplitByRune returns an iterator over the substrings of the input string
 // between occurences of the provided rune.
 func SplitByRune(s string, r rune) *Iter[string] {
-	return Wrap[string](&splitByRuneInner{s, r, 0})
-}
+	runes := []rune(s)
+	index := 0
 
-func (i *splitByRuneInner) HasNext() bool {
-	return i.index < len(i.string)
-}
+	tmp := Iter[string](func() (string, bool) {
+		newIndex := index
+		if len(runes) > index {
+			for newIndex < len(runes) {
+				if runes[newIndex] == r {
+					break
+				}
+				newIndex++
+			}
 
-func (i *splitByRuneInner) Next() (string, error) {
-	if !i.HasNext() {
-		return "", IteratorExhaustedError
-	}
-
-	runeIndex := strings.IndexRune(i.string[i.index:], i.rune)
-
-	if runeIndex == -1 {
-		res := i.string[i.index:]
-		i.index = len(i.string)
-		return res, nil
-	} else {
-		res := i.string[i.index : i.index+runeIndex]
-		i.index = i.index + runeIndex + 1
-		return res, nil
-	}
+			res := runes[index:newIndex]
+			index = newIndex + 1
+			return string(res), true
+		} else {
+			return "", false
+		}
+	})
+	return &tmp
 }
 
 type splitByStringInner struct {
@@ -54,27 +46,24 @@ type splitByStringInner struct {
 // SplitByString returns an iterator over the substrings of the input string
 // between occurences of the provided separator string.
 func SplitByString(s string, sep string) *Iter[string] {
-	return Wrap[string](&splitByStringInner{s, sep, 0})
-}
+	index := 0
 
-func (i *splitByStringInner) HasNext() bool {
-	return i.index < len(i.string)
-}
+	tmp := Iter[string](func() (string, bool) {
+		if len(s) > index {
+			sepIndex := strings.Index(s[index:], sep)
 
-func (i *splitByStringInner) Next() (string, error) {
-	if !i.HasNext() {
-		return "", IteratorExhaustedError
-	}
-
-	sepIndex := strings.Index(i.string[i.index:], i.sep)
-
-	if sepIndex == -1 {
-		res := i.string[i.index:]
-		i.index = len(i.string)
-		return res, nil
-	} else {
-		res := i.string[i.index : i.index+sepIndex]
-		i.index = i.index + sepIndex + len(i.sep)
-		return res, nil
-	}
+			if sepIndex == -1 {
+				res := s[index:]
+				index = len(s)
+				return res, true
+			} else {
+				res := s[index : index+sepIndex]
+				index += sepIndex + len(sep)
+				return res, true
+			}
+		} else {
+			return "", false
+		}
+	})
+	return &tmp
 }

--- a/string.go
+++ b/string.go
@@ -3,7 +3,7 @@ package iter
 import "strings"
 
 // Runes returns an iterator over the runes of the input string.
-func Runes(s string) *Iter[rune] {
+func Runes(s string) Iter[rune] {
 	runes := make([]rune, len(s))
 	for i, rune := range s {
 		runes[i] = rune
@@ -13,11 +13,11 @@ func Runes(s string) *Iter[rune] {
 
 // SplitByRune returns an iterator over the substrings of the input string
 // between occurences of the provided rune.
-func SplitByRune(s string, r rune) *Iter[string] {
+func SplitByRune(s string, r rune) Iter[string] {
 	runes := []rune(s)
 	index := 0
 
-	tmp := Iter[string](func() (string, bool) {
+	return Iter[string](func() (string, bool) {
 		newIndex := index
 		if len(runes) > index {
 			for newIndex < len(runes) {
@@ -34,7 +34,6 @@ func SplitByRune(s string, r rune) *Iter[string] {
 			return "", false
 		}
 	})
-	return &tmp
 }
 
 type splitByStringInner struct {
@@ -45,10 +44,10 @@ type splitByStringInner struct {
 
 // SplitByString returns an iterator over the substrings of the input string
 // between occurences of the provided separator string.
-func SplitByString(s string, sep string) *Iter[string] {
+func SplitByString(s string, sep string) Iter[string] {
 	index := 0
 
-	tmp := Iter[string](func() (string, bool) {
+	return Iter[string](func() (string, bool) {
 		if len(s) > index {
 			sepIndex := strings.Index(s[index:], sep)
 
@@ -65,5 +64,4 @@ func SplitByString(s string, sep string) *Iter[string] {
 			return "", false
 		}
 	})
-	return &tmp
 }

--- a/take.go
+++ b/take.go
@@ -1,27 +1,18 @@
 package iter
 
-type takeInner[T any] struct {
-	inner *Iter[T]
-	curr  int
-	max   int
-}
-
 // Take returns an iterator that limits that yields up to (but no more than) n
 // values from the input iterator.
 func (i *Iter[T]) Take(n int) *Iter[T] {
-	return Wrap[T](&takeInner[T]{inner: i, max: n})
-}
+	curr := 0
 
-func (i *takeInner[T]) HasNext() bool {
-	return i.curr < i.max && i.inner.HasNext()
-}
-
-func (i *takeInner[T]) Next() (T, error) {
-	if i.curr < i.max {
-		i.curr++
-		return i.inner.Next()
-	} else {
-		var z T
-		return z, IteratorExhaustedError
-	}
+	tmp := Iter[T](func() (T, bool) {
+		if curr < n {
+			curr++
+			return i.Next()
+		} else {
+			var z T
+			return z, false
+		}
+	})
+	return &tmp
 }

--- a/take.go
+++ b/take.go
@@ -2,17 +2,16 @@ package iter
 
 // Take returns an iterator that limits that yields up to (but no more than) n
 // values from the input iterator.
-func (i *Iter[T]) Take(n int) *Iter[T] {
+func (i Iter[T]) Take(n int) Iter[T] {
 	curr := 0
 
-	tmp := Iter[T](func() (T, bool) {
+	return Iter[T](func() (T, bool) {
 		if curr < n {
 			curr++
-			return i.Next()
+			return i()
 		} else {
 			var z T
 			return z, false
 		}
 	})
-	return &tmp
 }

--- a/take_while.go
+++ b/take_while.go
@@ -5,12 +5,12 @@ package iter
 // occurs, no more values are yielded. If this occurs, the previously yielded
 // values, as well as the first failing value, are consumed from the input
 // iterator.
-func (i *Iter[T]) TakeWhile(f func(T) bool) *Iter[T] {
+func (i Iter[T]) TakeWhile(f func(T) bool) Iter[T] {
 	failed := false
 
-	tmp := Iter[T](func() (T, bool) {
+	return Iter[T](func() (T, bool) {
 		if !failed {
-			next, ok := i.Next()
+			next, ok := i()
 			if ok {
 				if f(next) {
 					return next, true
@@ -23,5 +23,4 @@ func (i *Iter[T]) TakeWhile(f func(T) bool) *Iter[T] {
 		var z T
 		return z, false
 	})
-	return &tmp
 }

--- a/take_while.go
+++ b/take_while.go
@@ -1,78 +1,27 @@
 package iter
 
-type takeWhileInner[T any] struct {
-	inner         *Iter[T]
-	takeWhileFunc func(T) bool
-	cachedNext    *T
-	failed        bool
-}
-
 // TakeWhile produces a new iterator that yields values from the input iterator
 // while those values satisfy the provided function. Once the first failure
 // occurs, no more values are yielded. If this occurs, the previously yielded
 // values, as well as the first failing value, are consumed from the input
 // iterator.
 func (i *Iter[T]) TakeWhile(f func(T) bool) *Iter[T] {
-	return Wrap[T](&takeWhileInner[T]{inner: i, takeWhileFunc: f})
-}
+	failed := false
 
-func (i *takeWhileInner[T]) findNext() (T, error) {
-	for {
-		next, err := i.inner.Next()
+	tmp := Iter[T](func() (T, bool) {
+		if !failed {
+			next, ok := i.Next()
+			if ok {
+				if f(next) {
+					return next, true
+				}
+			}
 
-		if err != nil {
-			break
+			failed = true
 		}
 
-		if ok := i.takeWhileFunc(next); ok {
-			return next, nil
-		} else {
-			break
-		}
-	}
-	var z T
-	return z, IteratorExhaustedError
-}
-
-func (i *takeWhileInner[T]) HasNext() bool {
-	if i.failed {
-		return false
-	}
-
-	if i.cachedNext != nil {
-		return true
-	}
-
-	next, err := i.findNext()
-
-	if err == nil {
-		i.cachedNext = &next
-		return true
-	} else {
-		i.failed = true
-		return false
-	}
-}
-
-func (i *takeWhileInner[T]) Next() (T, error) {
-	if i.failed {
 		var z T
-		return z, IteratorExhaustedError
-	}
-
-	if i.cachedNext != nil {
-		res := *i.cachedNext
-		i.cachedNext = nil
-		return res, nil
-	}
-
-	next, err := i.findNext()
-
-	if err != nil {
-		i.failed = true
-		var z T
-		return z, IteratorExhaustedError
-	}
-
-	return next, nil
+		return z, false
+	})
+	return &tmp
 }

--- a/take_while_test.go
+++ b/take_while_test.go
@@ -9,8 +9,8 @@ import (
 func TestTakeWhile(t *testing.T) {
 	iter := Ints[int]().TakeWhile(func(i int) bool { return i < 10 })
 
-	test.Assert(iter.HasNext(), t)
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 
 	test.AssertDeepEq(
 		iter.Collect(),
@@ -19,11 +19,11 @@ func TestTakeWhile(t *testing.T) {
 
 	iter = Ints[int]().Take(0).TakeWhile(func(i int) bool { return i < 10 })
 
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 
 	iter.Collect()
 
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 
 	_, err := iter.Next()
 

--- a/take_while_test.go
+++ b/take_while_test.go
@@ -25,7 +25,7 @@ func TestTakeWhile(t *testing.T) {
 
 	// test.Assert(!iter.HasNext(), t)
 
-	_, err := iter.Next()
+	_, err := iter()
 
 	test.AssertNonNil(err, t)
 }

--- a/zip.go
+++ b/zip.go
@@ -3,16 +3,16 @@ package iter
 import "github.com/barweiss/go-tuple"
 
 type zipInner[T, U any] struct {
-	innerA *Iter[T]
-	innerB *Iter[U]
+	innerA Iter[T]
+	innerB Iter[U]
 }
 
 // Zip returns an iterator that yields tuples of the two provided input
 // iterators.
-func Zip[T, U any](a *Iter[T], b *Iter[U]) *Iter[tuple.T2[T, U]] {
-	tmp := Iter[tuple.T2[T, U]](func() (tuple.T2[T, U], bool) {
-		nextA, okA := a.Next()
-		nextB, okB := b.Next()
+func Zip[T, U any](a Iter[T], b Iter[U]) Iter[tuple.T2[T, U]] {
+	return Iter[tuple.T2[T, U]](func() (tuple.T2[T, U], bool) {
+		nextA, okA := a()
+		nextB, okB := b()
 		if okA && okB {
 			return tuple.New2(nextA, nextB), true
 		} else {
@@ -20,24 +20,23 @@ func Zip[T, U any](a *Iter[T], b *Iter[U]) *Iter[tuple.T2[T, U]] {
 			return z, false
 		}
 	})
-	return &tmp
 }
 
 // Enumerate returns an iterator of tuples indices and values from the input
 // iterator.
-func Enumerate[T any](i *Iter[T]) *Iter[tuple.T2[int, T]] {
+func Enumerate[T any](i Iter[T]) Iter[tuple.T2[int, T]] {
 	return Zip(Ints[int](), i)
 }
 
 type unzipInner1[T, U any] struct {
-	inner  *Iter[tuple.T2[T, U]]
+	inner  Iter[tuple.T2[T, U]]
 	other  *unzipInner2[T, U]
 	cached []T
 	index  int
 }
 
 type unzipInner2[T, U any] struct {
-	inner  *Iter[tuple.T2[T, U]]
+	inner  Iter[tuple.T2[T, U]]
 	other  *unzipInner1[T, U]
 	cached []U
 	index  int
@@ -48,43 +47,41 @@ type unzipInner2[T, U any] struct {
 // tuples. Note that, while the input iterator is evaluated lazily,
 // exceptionally inequal consumption of the left vs the right iterator can lead
 // to high memory consumption by values cached for the other iterator.
-func Unzip[T, U any](i *Iter[tuple.T2[T, U]]) (*Iter[T], *Iter[U]) {
+func Unzip[T, U any](i Iter[tuple.T2[T, U]]) (Iter[T], Iter[U]) {
 	var aCache []T
 	var bCache []U
 
 	// PERF: does using an index instead of reassigning the slice improve things?
 
-	tmpA := Iter[T](func() (T, bool) {
-		if len(aCache) == 0 {
-			next, ok := i.Next()
-			if !ok {
-				var z T
-				return z, false
-			}
+	return Iter[T](func() (T, bool) {
+			if len(aCache) == 0 {
+				next, ok := i()
+				if !ok {
+					var z T
+					return z, false
+				}
 
-			bCache = append(bCache, next.V2)
-			return next.V1, true
-		} else {
-			res := aCache[0]
-			aCache = aCache[1:]
-			return res, true
-		}
-	})
-	tmpB := Iter[U](func() (U, bool) {
-		if len(bCache) == 0 {
-			next, ok := i.Next()
-			if !ok {
-				var z U
-				return z, false
+				bCache = append(bCache, next.V2)
+				return next.V1, true
+			} else {
+				res := aCache[0]
+				aCache = aCache[1:]
+				return res, true
 			}
+		}), Iter[U](func() (U, bool) {
+			if len(bCache) == 0 {
+				next, ok := i()
+				if !ok {
+					var z U
+					return z, false
+				}
 
-			aCache = append(aCache, next.V1)
-			return next.V2, true
-		} else {
-			res := bCache[0]
-			bCache = bCache[1:]
-			return res, true
-		}
-	})
-	return &tmpA, &tmpB
+				aCache = append(aCache, next.V1)
+				return next.V2, true
+			} else {
+				res := bCache[0]
+				bCache = bCache[1:]
+				return res, true
+			}
+		})
 }

--- a/zip.go
+++ b/zip.go
@@ -7,36 +7,21 @@ type zipInner[T, U any] struct {
 	innerB *Iter[U]
 }
 
-// TODO: figure out why this is an issue, or file a bug report
-// func (i *Iter[T]) ZipEndo(o *Iter[T]) *Iter[tuple.T2[T, T]] {
-// 	return WithInner[tuple.T2[T, T]](&zipInner[T, T]{innerA: i, innerB: o})
-// }
-
 // Zip returns an iterator that yields tuples of the two provided input
 // iterators.
 func Zip[T, U any](a *Iter[T], b *Iter[U]) *Iter[tuple.T2[T, U]] {
-	return Wrap[tuple.T2[T, U]](&zipInner[T, U]{innerA: a, innerB: b})
+	tmp := Iter[tuple.T2[T, U]](func() (tuple.T2[T, U], bool) {
+		nextA, okA := a.Next()
+		nextB, okB := b.Next()
+		if okA && okB {
+			return tuple.New2(nextA, nextB), true
+		} else {
+			var z tuple.T2[T, U]
+			return z, false
+		}
+	})
+	return &tmp
 }
-
-func (i *zipInner[T, U]) HasNext() bool {
-	return i.innerA.HasNext() && i.innerB.HasNext()
-}
-
-func (i *zipInner[T, U]) Next() (tuple.T2[T, U], error) {
-	nextA, errA := i.innerA.Next()
-	nextB, errB := i.innerB.Next()
-
-	if errA == nil && errB == nil {
-		return tuple.New2(nextA, nextB), nil
-	} else {
-		var z tuple.T2[T, U]
-		return z, IteratorExhaustedError
-	}
-}
-
-// func (i *Iter[T]) Enumerate() *Iter[tuple.T2[int, T]] {
-// 	return Zip(InfRange(0, 1), i)
-// }
 
 // Enumerate returns an iterator of tuples indices and values from the input
 // iterator.
@@ -64,52 +49,42 @@ type unzipInner2[T, U any] struct {
 // exceptionally inequal consumption of the left vs the right iterator can lead
 // to high memory consumption by values cached for the other iterator.
 func Unzip[T, U any](i *Iter[tuple.T2[T, U]]) (*Iter[T], *Iter[U]) {
-	inner1 := unzipInner1[T, U]{inner: i}
-	inner2 := unzipInner2[T, U]{inner: i}
-	inner1.other, inner2.other = &inner2, &inner1
-	return Wrap[T](&inner1), Wrap[U](&inner2)
-}
+	var aCache []T
+	var bCache []U
 
-func (i *unzipInner1[T, U]) HasNext() bool {
-	return i.index < len(i.cached) || i.inner.HasNext()
-}
+	// PERF: does using an index instead of reassigning the slice improve things?
 
-func (i *unzipInner2[T, U]) HasNext() bool {
-	return i.index < len(i.cached) || i.inner.HasNext()
-}
+	tmpA := Iter[T](func() (T, bool) {
+		if len(aCache) == 0 {
+			next, ok := i.Next()
+			if !ok {
+				var z T
+				return z, false
+			}
 
-func (i *unzipInner1[T, U]) Next() (T, error) {
-	if i.index < len(i.cached) {
-		res := i.cached[i.index]
-		i.index = i.index + 1
-		return res, nil
-	}
+			bCache = append(bCache, next.V2)
+			return next.V1, true
+		} else {
+			res := aCache[0]
+			aCache = aCache[1:]
+			return res, true
+		}
+	})
+	tmpB := Iter[U](func() (U, bool) {
+		if len(bCache) == 0 {
+			next, ok := i.Next()
+			if !ok {
+				var z U
+				return z, false
+			}
 
-	tup, err := i.inner.Next()
-
-	if err != nil {
-		var z T
-		return z, IteratorExhaustedError
-	}
-
-	i.other.cached = append(i.other.cached, tup.V2)
-	return tup.V1, nil
-}
-
-func (i *unzipInner2[T, U]) Next() (U, error) {
-	if i.index < len(i.cached) {
-		res := i.cached[i.index]
-		i.index = i.index + 1
-		return res, nil
-	}
-
-	tup, err := i.inner.Next()
-
-	if err != nil {
-		var z U
-		return z, IteratorExhaustedError
-	}
-
-	i.other.cached = append(i.other.cached, tup.V1)
-	return tup.V2, nil
+			aCache = append(aCache, next.V1)
+			return next.V2, true
+		} else {
+			res := bCache[0]
+			bCache = bCache[1:]
+			return res, true
+		}
+	})
+	return &tmpA, &tmpB
 }

--- a/zip_test.go
+++ b/zip_test.go
@@ -50,9 +50,9 @@ func TestUnzip(t *testing.T) {
 	// test.Assert(v1.HasNext(), t)
 	// test.Assert(v2.HasNext(), t)
 
-	v1First, _ := v1.Next()
-	v2First, _ := v2.Next()
-	v2Second, _ := v2.Next()
+	v1First, _ := v1()
+	v2First, _ := v2()
+	v2Second, _ := v2()
 
 	test.AssertDeepEq(
 		tuple.New2(append([]int{v1First}, v1.Collect()...),

--- a/zip_test.go
+++ b/zip_test.go
@@ -8,26 +8,10 @@ import (
 	"testing"
 )
 
-// TODO: uncomment this once ZipEndo is fixed
-// func TestZipEndo(t *testing.T) {
-// 	iter := Range(0, 9, 1)
-//
-// 	zipIter := iter.ZipEndo(iter)
-//
-// 	expected := []tuple.T2[int, int]{
-// 		tuple.New2(0, 1),
-// 		tuple.New2(2, 3),
-// 		tuple.New2(4, 5),
-// 		tuple.New2(6, 7),
-// 	}
-//
-// 	test.AssertDeepEq(zipIter.Collect(), expected, t)
-// }
-
 func TestZip(t *testing.T) {
 	iter := Zip(Elems([]rune{'a', 'b', 'c', 'd'}), IntsFrom(1))
 
-	test.Assert(iter.HasNext(), t)
+	// test.Assert(iter.HasNext(), t)
 
 	expected := []tuple.T2[rune, int]{
 		tuple.New2('a', 1),
@@ -37,7 +21,7 @@ func TestZip(t *testing.T) {
 	}
 
 	test.AssertDeepEq(iter.Collect(), expected, t)
-	test.Assert(!iter.HasNext(), t)
+	// test.Assert(!iter.HasNext(), t)
 }
 
 func BenchmarkZip(b *testing.B) {
@@ -63,8 +47,8 @@ func TestUnzip(t *testing.T) {
 	expected := tuple.New2(Ints[int]().Take(10).Collect(), IntsFromBy(10, -1).Take(10).Collect())
 	v1, v2 := Unzip(Zip(Elems(expected.V1), Elems(expected.V2)))
 
-	test.Assert(v1.HasNext(), t)
-	test.Assert(v2.HasNext(), t)
+	// test.Assert(v1.HasNext(), t)
+	// test.Assert(v2.HasNext(), t)
 
 	v1First, _ := v1.Next()
 	v2First, _ := v2.Next()
@@ -75,8 +59,8 @@ func TestUnzip(t *testing.T) {
 			append([]int{v2First, v2Second}, v2.Collect()...)),
 		expected,
 		t)
-	test.Assert(!v1.HasNext(), t)
-	test.Assert(!v2.HasNext(), t)
+	// test.Assert(!v1.HasNext(), t)
+	// test.Assert(!v2.HasNext(), t)
 }
 
 func BenchmarkUnzip(b *testing.B) {


### PR DESCRIPTION
This pull request refactors the whole library so that `Iter[T]` is defined as:

```go
type Iter[T any] func() (T, bool)
```

This results not only in significantly better performance (a whole 32% better on average!), but also in much simpler code. See 
[this file](https://github.com/mtoohey31/iter/files/7921449/performance-difference.csv) for exact performance changes, there are a few outliers where it seems there have been regressions, but I'll do what I can to improve those after this is merged.

## TODO After Merging

- [ ] Fix performance regressions
- [ ] Fix codecoverage again and remove commented test code
- [ ] Resolve `TODO` comments
- [ ] Add acknoledgements of those who suggested these changes to the README